### PR TITLE
separate power of two check to its own method for clarity

### DIFF
--- a/src/ClassConstants.php
+++ b/src/ClassConstants.php
@@ -41,6 +41,14 @@ trait ClassConstants
             return false;
         }
 
-        return ($status & $status - 1) === 0;
+        return self::isPowerOfTwo($status);
+    }
+
+    /**
+     * Checks if the provided integer is a power of two.
+     */
+    final public static function isPowerOfTwo(int $value): bool
+    {
+        return ($value & $value - 1) === 0;
     }
 }


### PR DESCRIPTION
Having a separate `isPowerOfTwo` check allows for easier understanding of what's actually happening.